### PR TITLE
fix &backupskip splitting

### DIFF
--- a/autoload/stay.vim
+++ b/autoload/stay.vim
@@ -36,7 +36,7 @@ endfunction
 " @returns:    Boolean
 if exists('*glob2regpat') " fastest option, Vim 7.4 with patch 668 only
   function! stay#istemp(path) abort
-    for l:tempdir in split(&backupskip, '\m[^\\]\%(\\\\\)*,')
+    for l:tempdir in split(&backupskip, '\m\s*,\s*')
       if a:path =~# glob2regpat(l:tempdir)
         return 1
       endif


### PR DESCRIPTION
Before, the delimiter would swallow the character before the separator ','